### PR TITLE
fix: NPE when deleting Barber service #18

### DIFF
--- a/src/main/java/com/piotrzawada/BarberShopBookingSystem/Controllers/BarberServiceModelController.java
+++ b/src/main/java/com/piotrzawada/BarberShopBookingSystem/Controllers/BarberServiceModelController.java
@@ -84,6 +84,11 @@ public class BarberServiceModelController {
     public ResponseEntity<Response> delete(String name) {
         Response response = new Response();
 
+        if (service.getByName(name) == null) {
+            response.setMessage("Error: This does not exist");
+            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        }
+
         service.deleteByName(name);
 
         response.setMessage("This Service has been successfully deleted");

--- a/src/main/java/com/piotrzawada/BarberShopBookingSystem/Controllers/BarberServiceModelController.java
+++ b/src/main/java/com/piotrzawada/BarberShopBookingSystem/Controllers/BarberServiceModelController.java
@@ -68,6 +68,12 @@ public class BarberServiceModelController {
         Response response = new Response();
 
         BarberServiceModel barberService =  service.getByName(name);
+
+        if (barberService== null) {
+            response.setMessage("Error: This service does not exist");
+            return new ResponseEntity<>(response, HttpStatus.NOT_FOUND);
+        }
+
         barberService.setPrice(newPrice);
 
         service.save(barberService);

--- a/src/test/java/com/piotrzawada/BarberShopBookingSystem/Controllers/BarberServiceModelControllerTest.java
+++ b/src/test/java/com/piotrzawada/BarberShopBookingSystem/Controllers/BarberServiceModelControllerTest.java
@@ -146,6 +146,20 @@ class BarberServiceModelControllerTest {
                 .andDo(MockMvcResultHandlers.print());
         Assertions.assertEquals(20.00, standard.getPrice());
     }
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    void editPrice_byRoleUser_isNotFound() throws Exception {
+        given(service.getByName(ArgumentMatchers.anyString())).willReturn(null);
+
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.put("/api/services/update")
+                .param("name", "standard")
+                .param("newPrice", "25.50")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(standard)));
+
+        resultActions.andExpect(MockMvcResultMatchers.status().isNotFound())
+                .andDo(MockMvcResultHandlers.print());
+    }
 
     @Test
     @WithMockUser(username = "admin", roles = {"ADMIN"})

--- a/src/test/java/com/piotrzawada/BarberShopBookingSystem/Controllers/BarberServiceModelControllerTest.java
+++ b/src/test/java/com/piotrzawada/BarberShopBookingSystem/Controllers/BarberServiceModelControllerTest.java
@@ -150,12 +150,24 @@ class BarberServiceModelControllerTest {
     @Test
     @WithMockUser(username = "admin", roles = {"ADMIN"})
     void delete_isNoContent() throws Exception {
+        given(service.getByName(ArgumentMatchers.anyString())).willReturn(standard);
         ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.delete("/api/services/delete")
                 .param("name", "standard")
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(standard)));
 
         resultActions.andExpect(MockMvcResultMatchers.status().isNoContent());
+    }
+    @Test
+    @WithMockUser(username = "admin", roles = {"ADMIN"})
+    void delete_isNotFound() throws Exception {
+        given(service.getByName(ArgumentMatchers.anyString())).willReturn(null);
+        ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders.delete("/api/services/delete")
+                .param("name", "standard")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(standard)));
+
+        resultActions.andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 
     @Test


### PR DESCRIPTION
The program was throwing a NullPointerException (NPE) when attempting to
 delete a BarberService object that was null.

The issue has been resolved by slightly modifying the method in BarberServiceController. Additionally, the existing test method has been fixed, and a new test method has been added to handle cases where the BarberService object is null.